### PR TITLE
Harden topic validation and startup checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ros2 run rclcpp_components component_container
 ros2 component load /ComponentManager wisevision_lorawan_bridge wisevision::LoraWanBridge --parameter application_id:=<APPLICATION_ID> --parameter use_only_standard:=false
 ```
 
-## Start LoRaWAN bridge in Docker container
+## Start LoRaWAN bridge in [Docker](https://www.docker.com) container
 
 
 1. Run docker-compose

--- a/standard_parser/include/standard_parser/utils.hpp
+++ b/standard_parser/include/standard_parser/utils.hpp
@@ -11,10 +11,11 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace wisevision::utils {
   std::string convertBinaryToHexString(const std::vector<uint8_t>& bytes);
-  std::vector<uint8_t> convertHexStringToBinary(const std::string& str);
+  std::optional<std::vector<uint8_t>> convertHexStringToBinary(const std::string& str);
 } // namespace wisevision::utils

--- a/standard_parser/src/standard_parser.cpp
+++ b/standard_parser/src/standard_parser.cpp
@@ -16,8 +16,11 @@ namespace wisevision {
     std_msgs::msg::String ros_message;
     m_serde.deserialize_message(&message, &ros_message);
     const auto& hex_encoded_downlink = ros_message.data;
-    const auto binary = utils::convertHexStringToBinary(hex_encoded_downlink);
-    return binary;
+    const auto binary_opt = utils::convertHexStringToBinary(hex_encoded_downlink);
+    if (!binary_opt.has_value()) {
+      return std::nullopt;
+    }
+    return binary_opt.value();
   };
 
   std::optional<rclcpp::SerializedMessage> StandardParser::bytesToRosMessage(const std::vector<uint8_t>& bytes) {

--- a/standard_parser/src/utils.cpp
+++ b/standard_parser/src/utils.cpp
@@ -10,7 +10,8 @@
 
 #include "standard_parser/utils.hpp"
 
-#include <cassert>
+#include <algorithm>
+#include <cctype>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -25,11 +26,17 @@ namespace wisevision::utils {
     return hex_stream.str();
   }
 
-  std::vector<uint8_t> convertHexStringToBinary(const std::string& str) {
-    assert(str.size() % 2 == 0);
+  std::optional<std::vector<uint8_t>> convertHexStringToBinary(const std::string& str) {
+    if (str.size() % 2 != 0) {
+      return std::nullopt;
+    }
+    if (!std::all_of(str.begin(), str.end(), [](const unsigned char c) { return std::isxdigit(c) != 0; })) {
+      return std::nullopt;
+    }
+
     std::vector<uint8_t> binary(str.size() / 2);
-    for (size_t i = 0; i < str.size() - 1; i += 2) {
-      binary[i / 2] = std::stoi(str.substr(i, 2), nullptr, 16);
+    for (size_t i = 0; i < str.size(); i += 2) {
+      binary[i / 2] = static_cast<uint8_t>(std::stoi(str.substr(i, 2), nullptr, 16));
     }
     return binary;
   }

--- a/wisevision_lorawan_bridge/include/wisevision_lorawan_bridge/lorawan_bridge.hpp
+++ b/wisevision_lorawan_bridge/include/wisevision_lorawan_bridge/lorawan_bridge.hpp
@@ -13,6 +13,7 @@
 #include <mqtt/async_client.h>
 #include <mqtt/delivery_token.h>
 #include <rclcpp/rclcpp.hpp>
+#include <optional>
 #include <unordered_map>
 #include <wisevision_parser/parser.hpp>
 
@@ -37,6 +38,11 @@ namespace wisevision {
     size_t port; // cppcheck-suppress unusedStructMember
   };
 
+  struct ParsedTopic {
+    std::string device_eui;
+    EventType event_type;
+  };
+
   EventType eventTypeFromString(const std::string& event_type);
 
   class LoraWanBridge : public rclcpp::Node, public virtual mqtt::callback {
@@ -58,8 +64,7 @@ namespace wisevision {
     size_t m_devices_list_pagination;
 
     bool setupParameters();
-    std::string getDeviceEuiFromTopic(const std::string& topic);
-    EventType getEventTypeFromTopic(const std::string& topic);
+    std::optional<ParsedTopic> parseTopic(const std::string& topic) const;
     void publishToMqtt(const std::string& device_eui, const std::vector<uint8_t>& payload);
     bool connectToApi(const ClientConfiguration& configuration);
     std::optional<std::unordered_map<std::string, Device::UniquePtr>> initializeDevices();

--- a/wisevision_lorawan_bridge/src/lorawan_bridge.cpp
+++ b/wisevision_lorawan_bridge/src/lorawan_bridge.cpp
@@ -10,6 +10,7 @@
 
 #include "wisevision_lorawan_bridge/lorawan_bridge.hpp"
 
+#include <chrono>
 #include <grpcpp/create_channel.h>
 
 #include "chirpstack_api/integration/integration.pb.h"
@@ -28,7 +29,13 @@ namespace wisevision {
                                                              std::to_string(m_mqtt_broker_parameters.port),
                                                          "lorawan_bridge");
     m_mqtt_client->set_callback(*this);
-    m_mqtt_client->connect();
+    try {
+      m_mqtt_client->connect()->wait();
+    } catch (const mqtt::exception& ex) {
+      RCLCPP_FATAL(this->get_logger(), "Cannot connect to MQTT broker: %s", ex.what());
+      rclcpp::shutdown();
+      return;
+    }
 
     if (!connectToApi(m_api_parameters)) {
       RCLCPP_FATAL(this->get_logger(), "Cannot connect to API. Exiting...");
@@ -75,7 +82,14 @@ namespace wisevision {
   void LoraWanBridge::message_arrived(mqtt::const_message_ptr msg) {
     RCLCPP_DEBUG(this->get_logger(), "Received MQTT message from topic: %s", msg->get_topic().c_str());
     const auto topic = msg->get_topic();
-    const auto device_eui = getDeviceEuiFromTopic(topic);
+    const auto parsed_topic_opt = parseTopic(topic);
+    if (!parsed_topic_opt.has_value()) {
+      RCLCPP_WARN(this->get_logger(), "Skipping MQTT message with unexpected topic format: %s", topic.c_str());
+      return;
+    }
+
+    const auto& parsed_topic = parsed_topic_opt.value();
+    const auto& device_eui = parsed_topic.device_eui;
     if (m_devices.find(device_eui) == m_devices.end()) {
       RCLCPP_WARN(this->get_logger(),
                   "There is no device defined with EUI \"%s\" from topic \"%s\"",
@@ -84,8 +98,7 @@ namespace wisevision {
       return;
     }
 
-    const auto event_type = getEventTypeFromTopic(topic);
-    switch (event_type) {
+    switch (parsed_topic.event_type) {
     case EventType::Up: {
       const auto raw_payload = msg->get_payload();
       integration::UplinkEvent uplink;
@@ -107,9 +120,15 @@ namespace wisevision {
   bool LoraWanBridge::connectToApi(const ClientConfiguration& configuration) {
     const auto channel = grpc::CreateChannel(configuration.host + ":" + std::to_string(configuration.port),
                                              grpc::InsecureChannelCredentials());
+    if (!channel->WaitForConnected(std::chrono::system_clock::now() + std::chrono::seconds(5))) {
+      RCLCPP_ERROR(this->get_logger(),
+                   "Cannot establish gRPC channel to ChirpStack API at %s:%ld",
+                   configuration.host.c_str(),
+                   configuration.port);
+      return false;
+    }
     m_device_client = api::DeviceService::NewStub(channel);
-    // TODO(styczen): Check if it is possible to do health check the server.
-    return true;
+    return m_device_client != nullptr;
   }
 
   std::optional<std::unordered_map<std::string, Device::UniquePtr>> LoraWanBridge::initializeDevices() {
@@ -210,14 +229,14 @@ namespace wisevision {
                            serialized_downlink);
   }
 
-  std::string LoraWanBridge::getDeviceEuiFromTopic(const std::string& topic) {
-    auto tokens = utils::splitStringByDelimiter(topic, "/");
-    return tokens[3];
-  }
+  std::optional<ParsedTopic> LoraWanBridge::parseTopic(const std::string& topic) const {
+    const auto tokens = utils::splitStringByDelimiter(topic, "/");
+    if (tokens.size() != 6 || tokens[0] != "application" || tokens[1] != m_application_id || tokens[2] != "device" ||
+        tokens[4] != "event" || tokens[3].empty() || tokens[5].empty()) {
+      return std::nullopt;
+    }
 
-  EventType LoraWanBridge::getEventTypeFromTopic(const std::string& topic) {
-    auto tokens = utils::splitStringByDelimiter(topic, "/");
-    return eventTypeFromString(tokens[5]);
+    return ParsedTopic {tokens[3], eventTypeFromString(tokens[5])};
   }
 
   bool LoraWanBridge::setupParameters() {


### PR DESCRIPTION
## Summary
- validate expected MQTT topic structure before extracting device EUI and event type
- make standard parser hex handling safe for invalid input
- add fail-fast startup checks for MQTT and gRPC connectivity

## Verification
- reviewed logic changes in the main topic parsing and startup flow
- verified local compilation of the changed standard_parser utility source
- full colcon build was not available in this environment
